### PR TITLE
Return 'email_verified' prop in userinfo to improve app compat

### DIFF
--- a/DevOidcToolkit/Controllers/ConnectController.cs
+++ b/DevOidcToolkit/Controllers/ConnectController.cs
@@ -275,6 +275,7 @@ public class ConnectController(ILogger<ConnectController> logger,
             if (email != null)
             {
                 claims["email"] = email;
+                claims["email_verified"] = "true";
             }
         }
 


### PR DESCRIPTION
This makes dev-oidc-toolkit work with the https://pocketbase.io project (https://github.com/pocketbase/pocketbase), which fails if email_verified is missing.