### PR TITLE
feat: add post_logout_redirect_uri support

### DIFF
--- a/DevOidcToolkit/Infrastructure/Configuration/Configuration.cs
+++ b/DevOidcToolkit/Infrastructure/Configuration/Configuration.cs
@@ -32,6 +32,7 @@ public class ClientConfiguration
     [Required] public required string Secret { get; set; }
 
     public List<string> RedirectUris { get; set; } = [];
+    public List<string> PostLogoutRedirectUris { get; set; } = [];
 }
 
 public class HttpsConfiguration

--- a/DevOidcToolkit/Program.cs
+++ b/DevOidcToolkit/Program.cs
@@ -189,6 +189,7 @@ using (var scope = app.Services.CreateScope())
             Permissions = {
                 Permissions.Endpoints.Authorization,
                 Permissions.Endpoints.Token,
+                Permissions.Endpoints.EndSession,
 
                 Permissions.GrantTypes.AuthorizationCode,
                 Permissions.ResponseTypes.Code,
@@ -199,6 +200,7 @@ using (var scope = app.Services.CreateScope())
             ConsentType = ConsentTypes.Explicit
         };
         client.RedirectUris.ForEach(redirectUri => clientApp.RedirectUris.Add(new Uri(redirectUri)));
+        client.PostLogoutRedirectUris.ForEach(redirectUri => clientApp.PostLogoutRedirectUris.Add(new Uri(redirectUri)));
         await openIddictManager.CreateAsync(clientApp);
     }
 }

--- a/DevOidcToolkit/config.json
+++ b/DevOidcToolkit/config.json
@@ -14,6 +14,9 @@
         "Secret": "secret",
         "RedirectUris": [
           "http://localhost:3000/signin-oidc"
+        ],
+        "PostLogoutRedirectUris": [
+          "http://localhost:3000/signout-callback-oidc"
         ]
       }
     ]


### PR DESCRIPTION
This PR adds the ability to configure post_logout_redirect_uri's.

It adds a new property in the ClientConfiguration, and configures it with openiddict. 

Before, when trying to logout, there would be an error indicating post_login_redirect_uri is invalid. When inspecting the client configuration in the web ui, the property "PostLogoutRedirectUris" was empty, with this PR, the property is correctly set.
<img width="789" height="800" alt="image" src="https://github.com/user-attachments/assets/e5f58df3-75ca-4426-9539-88264e40e813" />
